### PR TITLE
Compile and run opencl version of caffe for android #22

### DIFF
--- a/package/lib-clblast-trunk-android/.cm/meta.json
+++ b/package/lib-clblast-trunk-android/.cm/meta.json
@@ -3,7 +3,7 @@
     "extra_dir": "",
     "git_src_dir": "src",
     "install_env": {
-      "CLBLAST_URL": "https://github.com/CNugteren/CLBlast"
+      "CLBLAST_URL": "https://github.com/DVEfremov/CLBlast"
     },
     "use_git_revision": "yes",
     "version": "development"
@@ -30,7 +30,7 @@
     }
   },
   "end_full_path": {
-    "android": "install$#sep#$lib$#sep#$libclblast.so"
+    "android": "install$#sep#$lib$#sep#$libclblast.a"
   },
   "need_cpu_info": "yes",
   "only_for_host_os_tags": [

--- a/package/lib-clblast-trunk-android/install.sh
+++ b/package/lib-clblast-trunk-android/install.sh
@@ -49,6 +49,7 @@ cmake -DCMAKE_BUILD_TYPE=${CK_ENV_CMAKE_BUILD_TYPE:-Release} \
       -DOPENCL_LIBRARIES="${CK_ENV_LIB_OPENCL_LIB}/libOpenCL.so" \
       -DOPENCL_INCLUDE_DIRS="${CK_ENV_LIB_OPENCL_INCLUDE}" \
       -DCMAKE_INSTALL_PREFIX="${INSTALL_DIR}/install" \
+      -DBUILD_SHARED_LIBS=OFF \
       ../src
 
 ################################################################################

--- a/package/lib-viennacl-trunk-android/install.sh
+++ b/package/lib-viennacl-trunk-android/install.sh
@@ -16,6 +16,7 @@
 export VIENNACL_SRC_DIR=${INSTALL_DIR}/src
 export VIENNACL_OBJ_DIR=${INSTALL_DIR}/obj
 export VIENNACL_LIB_DIR=${INSTALL_DIR}/lib
+export VIENNACL_INCLUDE_DIR=${INSTALL_DIR}/include
 export VIENNACL_PATCH=${PACKAGE_DIR}/181.patch
 
 ################################################################################
@@ -105,3 +106,7 @@ if [ "$?" != "0" ]; then
   read -p "Press any key to continue!"
   exit $?
 fi
+
+mkdir -p
+cp -avr ${VIENNACL_SRC_DIR} ${VIENNACL_INCLUDE_DIR}
+


### PR DESCRIPTION
- fix caffe opencl compilation problem
  - static link clblast lib to caffe lib
  - fix missed include dir for voenacl install script